### PR TITLE
chore: Fix issues blocking the auto-merge script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Any and ALL code in this repository __SHOULD NOT BE USED FOR PRODUCTION__ as it 
 For production level support please use these repositories
 
 - [OpenTelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification)
-- [OpenTelemetry JS API](https://github.com/open-telemetry/opentelemetry-js-api)
+- [~~OpenTelemetry JS API~~](https://github.com/open-telemetry/opentelemetry-js-api) Now merged back into [OpenTelemetry JS](https://github.com/open-telemetry/opentelemetry-js)
 - [OpenTelemetry JS](https://github.com/open-telemetry/opentelemetry-js)
 - [OpenTelemetry JS Contrib](https://github.com/open-telemetry/opentelemetry-js-contrib)
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
       "author": "OpenTelemetry Authors",
       "license": "Apache-2.0",
       "scripts": {
-        "do-sandbox-repo-merge": "cd sandbox-tools/merge-repos && npm install && cd ../.. && npm run do-repo-merge --prefix sandbox-tools/merge-repos"
+        "do-sandbox-repo-merge": "cd sandbox-tools/merge-repos && npm install && cd ../.. && npm run do-repo-merge --prefix sandbox-tools/merge-repos --"
     },
     "repository": "open-telemetry/opentelemetry-sandbox-web-js",
     "homepage": "https://github.com/open-telemetry/opentelemetry-sandbox-web-js#readme",

--- a/sandbox-tools/merge-repos/README.md
+++ b/sandbox-tools/merge-repos/README.md
@@ -15,22 +15,21 @@ This script performs the following
 - Clone the `opentelemetry/opentelemetry-sandbox-web-js` staging branch `auto-merge/repo-staging` (must exist) into a local temporary folder (removing any previous local folder first)
 - Removes any possible "conflicting" files from the root of the merge branch (if present -- only needed for local testing and first run)
 - Loops through each configured repository and
-  - Adds a temporary Remotes for the repository to be merged.
-  - Creates a local branch of the remote repository
-  - Fetch and Checkout the remote repository
-  - Removes any untracked local files from this local branch
-  - Merges the remote repository into the local branch (bringing over all of the history) using `-X theirs` strategy option.
-  - Moves all of the files for the local branch into a sub folder within the local branch via `git mv`, so that all of the history is retained
-  - Commits the move to the local branch (including the files moved as part of the message) -- as this new "history" will get merged into the `merge-main`
-  - Renames ALL tags to include a configured prefix onto every tags `<prefix>/<original tag>`
-  - Removes the temporary remote
-- Once all configured repositories have been merged and moved within each of their own local branches it switches to the local `repo-staging` branch and for each configured repository
-  - Merges from the local remote branch into the `repo-staging` branch using `-X theirs`.
-  - Auto Resolves any merge conflicts that could not be auto resolved by ALWAYS selecting `theirs` (the local branch of the remote repository)
-  - Commits the changes into the local `repo-staging` branch
+  - Creates a local clone of the `source` (js/contrib) repository to be merged (synchronized to the configured `branchStartPoint` (defaults to HEAD))
+  - Renames ALL tags to include a configured prefix onto every tags `<repo-prefix>/<original tag>`
+  - Moves all of the files for the local clone into a sub folder (`auto-merge/<repo-prefix>`) via `git mv`, so that all of the history is retained
+  - Commits the move to the local branch (including the files moved as part of the message) -- as this new "history" will get merged into the `repo-staging`
+  - Adds a temporary Remote for the local `source` clone to the `repo-staging` repository.
+  - Creates a local branch of the `repo-staging` remote repository (for the current user `<user>/auto-merge-repo-staging`)
+  - Fetch, Checkout and sync to the remote repository
+  - Removes any untracked local files from this local branch (reset / clean)
+  - Merges from the local `source` clone  remote branch into the `<user>/auto-merge-repo-staging` branch using `-X theirs`.
+  - Auto Resolves any merge conflicts that could not be auto resolved by selecting `theirs` (for the local `source` branch of the remote repository)
+  - Commits the changes into the local `<user>/auto-merge-repo-staging` branch
 - At this point the hard work is now complete with the only follow up steps left are
-- Iterate over the configured repositories and delete the local branches created for report repository (without pushing)
+- Iterate over the configured repositories and verifies that the `source` branch contents (all folders / files) match the contents in `<user>/auto-merge-repo-staging`
+  - When this does not match (which does occur) it re-copies files that don't match and removes folders that the merge didn't auto remove.
 - Perform any final cleanup requested
-- Finally perform a `git push -f` to the cloned staging branch to the bot owner(s) fork `opentelemetrybot/auto-merge-repo-staging`
-- With the remote branch now on GitHub, it creates a PR to merge the fork branch `opentelemetrybot/auto-merge-repo-staging` into the sandbox `opentelemetry/opentelemetry-sandbox-web-js` repository `auto-merge/repo-staging` branch.
-
+- Finally perform a `git push -f` to the cloned staging branch to the bot owner(s) fork `<user>/auto-merge-repo-staging` (when running the github action `<user>` is `opentelemetrybot`)
+- With the remote branch now on GitHub, it creates a PR to merge the fork branch `<user>/auto-merge-repo-staging` into the sandbox `opentelemetry/opentelemetry-sandbox-web-js` repository `auto-merge/repo-staging` branch.
+- It also attempts to push all tags from local `<user>/auto-merge-repo-staging` to Github and the upstream `opentelemetry/opentelemetry-sandbox-web-js` (this may fail if permissions are not available)

--- a/sandbox-tools/merge-repos/src/config.ts
+++ b/sandbox-tools/merge-repos/src/config.ts
@@ -69,12 +69,14 @@ export const reposToSyncAndMerge: IRepoSyncDetails = {
         url: "https://github.com/open-telemetry/opentelemetry-js",
         branch: "main",
         //mergeStartPoint: "HEAD",    // Used for local testing to validate periodic execution
+        //branchStartPoint: "e91cac503c0bab95b429ff3c4b23249653882054",
         destFolder: MERGE_DEST_BASE_FOLDER + "/js"
     },
     "otel-js-contrib": {
         url: "https://github.com/open-telemetry/opentelemetry-js-contrib",
         branch: "main",
         //mergeStartPoint: "HEAD",    // Used for local testing to validate periodic execution
+        //branchStartPoint: "35226602b92a7587f16a1eb959e4f3b3948f6e9d",
         destFolder: MERGE_DEST_BASE_FOLDER + "/contrib"
     }
 };

--- a/sandbox-tools/merge-repos/src/git/renameTags.ts
+++ b/sandbox-tools/merge-repos/src/git/renameTags.ts
@@ -87,8 +87,6 @@ export async function renameTags(git: SimpleGit, theRepos: IRepoSyncDetails, pre
                 }
                 // Delete the old tag
                 await git.tag(["-d", tag]);
-            } else {
-                log(` - Ignoring ${tag}`);
             }
         }
     }

--- a/sandbox-tools/merge-repos/src/support/isIgnoreFolder.ts
+++ b/sandbox-tools/merge-repos/src/support/isIgnoreFolder.ts
@@ -30,7 +30,7 @@ export function isIgnoreFolder(theRepos: IRepoSyncDetails, source: string, isRoo
         return true;
     }
 
-    if (isRoot) {
+    if (isRoot && theRepos) {
         let repoNames = Object.keys(theRepos);
         for (let lp = 0; lp < repoNames.length; lp++) {
             let destFolder = theRepos[repoNames[lp]].destFolder;

--- a/sandbox-tools/merge-repos/src/support/moveTo.ts
+++ b/sandbox-tools/merge-repos/src/support/moveTo.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { SimpleGit } from "simple-git";
+import { reposToSyncAndMerge } from "../config";
+import { ICommitDetails } from "../git/commit";
+import { isIgnoreFolder } from "./isIgnoreFolder";
+import { log } from "./utils";
+
+async function moveFolder(git: SimpleGit, commitMessage: string, baseFolder: string, from: string, to: string, level: number) {
+
+    if (from !== to && !isIgnoreFolder(reposToSyncAndMerge, from, level === 0)) {
+        let moved = false;
+        let isSrcDir = false;
+        let inputStats = fs.statSync(baseFolder + "/" + from);
+        if (inputStats.isDirectory()) {
+            //log(` - ${fullInputPath}/`);
+            isSrcDir = true;
+
+            // Move the files independently
+            let dirs = [];
+            let fromFiles = [];
+
+            if (fs.existsSync(baseFolder + "/" + from)) {
+                let dirFiles = fs.readdirSync(baseFolder + "/" + from);
+                for (let lp = 0; lp < dirFiles.length; lp++) {
+                    let newFrom = (from ? (from + "/") : "") + dirFiles[lp];
+                    let newFromStats = fs.statSync(baseFolder + "/" + newFrom);
+                    if (newFromStats.isFile()) {
+                        fromFiles.push(newFrom);
+                    } else if (newFromStats.isDirectory() && !isIgnoreFolder(reposToSyncAndMerge, newFrom, level === 0)) {
+                        dirs.push(dirFiles[lp]);
+                    }
+                }
+            }
+
+            let toDirExists = false;
+            if (fs.existsSync(baseFolder + "/" + to)) {
+                let inputStats = fs.statSync(baseFolder + "/" + to);
+                if (inputStats.isDirectory()) {
+                    toDirExists = true;
+                } else {
+                    // Destination is a file!!!
+                }
+            }
+
+            if (fromFiles.length === 0 || level === 0 || toDirExists) {
+                if (!fs.existsSync(baseFolder + "/" + to)) {
+                    log(` - (Creating) ${baseFolder + "/" + to}`);
+                    fs.mkdirSync(baseFolder + "/" + to, { recursive: true });
+                }
+
+                for (let lp = 0; lp < fromFiles.length; lp++) {
+                    log(` - (File) ${fromFiles[lp]} -> ${to}`);
+                    await git.raw([
+                        "mv",
+                        "--force",
+                        "--verbose",
+                        path.normalize(fromFiles[lp]),
+                        path.normalize(to)
+                    ]);
+                }
+
+                for (let lp = 0; lp < dirs.length; lp++) {
+                    let newFrom = (from ? (from + "/") : "") + dirs[lp];
+                    let newTo = to + "/" + dirs[lp]
+                    log(` - (Move) ${newFrom} -> ${newTo}`);
+                    commitMessage = await moveFolder(git, commitMessage, baseFolder, newFrom, newTo, level + 1);
+                }
+            } else {
+                log(` - (Moving) ${from} -> ${to}`);
+                await git.raw([
+                    "mv",
+                    "--force",
+                    "--verbose",
+                    path.normalize(from),
+                    path.normalize(to + "/..")
+                ]);
+            }
+
+            // Make sure everything got moved
+            if (fs.existsSync(baseFolder + "/" + from)) {
+                const checkFiles = fs.readdirSync(baseFolder + "/" + from);
+                let fromCnt = 0;
+                for (let lp = 0; lp < checkFiles.length; lp++) {
+                    if (!isIgnoreFolder(null, checkFiles[lp], level === 0)) {
+                        let checkStats = fs.statSync(baseFolder + "/" + from + "/" + checkFiles[lp]);
+                        if (checkStats.isFile()) {
+                            fromCnt ++;
+                        }
+                    }
+                }
+
+                if (from && fromCnt > 0) {
+                    log(`!!! Not all files moved!!) ${fromCnt + " - " + from}`);
+                    throw "Not all files moved!!";
+                }
+
+                if (from && fromCnt === 0) {
+                    // cleanup the from folder
+                    log(` - (unlinking) ${baseFolder + "/" + from}`);
+                    fs.rmdirSync(baseFolder + "/" + from, {
+                        recursive: true
+                    });
+                }
+            }
+
+            moved = true;
+        }
+
+        if (!moved) {
+            log(` - ${from + (isSrcDir ? "/" : "")} => ${to}`);
+            await git.raw([
+                "mv",
+                "--force",
+                "--verbose",
+                path.normalize(from + (isSrcDir ? "/" : "")),
+                path.normalize(to)
+            ]);
+
+            commitMessage = appendCommitMessage(commitMessage, ` - ${from}${isSrcDir ? "/" : ""}`)
+        }
+    } else {
+        log(` - Ignoring ${from}  (${to})`);
+    }
+
+    return commitMessage;
+}
+
+function appendCommitMessage(commitMessage: string, message: string) {
+    if (commitMessage.length + message.length < 2048) {
+        commitMessage += `\n${message}`;
+    } else if (commitMessage.indexOf("...truncated...") === -1) {
+        commitMessage += "\n...truncated...";
+    }
+
+    return commitMessage;
+}
+
+/**
+ * Move the repo files into the destFolder, this is called recursively as `git mv` sometimes complains when moving
+ * a folder which already exists, this occurs when a previous PR moved the file/folders and new files/folders are
+ * added to the original location that now needs to be moved.
+ * @param git - The SimpleGit instance for the repo to use
+ * @param baseFolder - The base folder for the git instance
+ * @param srcFolder - The source folder to be moved
+ * @param destFolder - The destination folder to move the source folder to
+ * @param commitDetails - Holds the commit details, used to generate the commit message
+ */
+ export async function moveRepoTo(git: SimpleGit, baseFolder: string, srcFolder: string, destFolder: string, commitDetails: ICommitDetails) {
+
+    let theLocalDestPath = path.resolve(path.join(baseFolder, destFolder)).replace(/\\/g, "/") + "/";
+    let theGitDestFolder = destFolder;
+
+    if (srcFolder.length === 0) {
+        // Don't log this if we are in recursively moving
+        log(`Moving Repo to ${theGitDestFolder}; Local dest path: ${theLocalDestPath}`);
+    }
+
+    const files = fs.readdirSync(baseFolder + "/" + srcFolder);
+    log(`${files.length} file(s) found in ${baseFolder + "/" + srcFolder} to move`);
+    if (!fs.existsSync(theLocalDestPath)) {
+        fs.mkdirSync(theLocalDestPath, { recursive: true });
+    }
+
+    if (files.length > 0) {
+        let commitMessage = commitDetails.message;
+
+        if (srcFolder.length === 0) {
+            commitMessage += `\n### Moving files from ${srcFolder ? srcFolder : "./"} to ${theGitDestFolder}`
+        }
+
+        commitMessage = await moveFolder(git, commitMessage, baseFolder, srcFolder, theGitDestFolder, 0);
+
+        commitDetails.message = commitMessage;
+    } else {
+        log(` - No files found in ${baseFolder + "/" + srcFolder}`);
+    }
+}
+

--- a/sandbox-tools/merge-repos/src/support/types.ts
+++ b/sandbox-tools/merge-repos/src/support/types.ts
@@ -33,6 +33,12 @@ export declare type CleanupFunc = (git: SimpleGit) => Promise<any>;
     branch: string;
 
     /**
+     * [Optional] Identifies the point on the source branch to be merged into the auto-merge branch.
+     * Defaults to undefined and therefore the HEAD of the specified branch
+     */
+    branchStartPoint?: string;
+
+    /**
      * The prefix to apply to remote tags when merging into the destination repo.
      * If not defined defaults to the <repo key name>
      */


### PR DESCRIPTION
The initial merge script was tested heavily against the API and JS repositories, and the configuration was changed to use JS and CONTRIB repositories, however, while API and JS did not have merge clashes JS and CONTRIB has some unexpected and unhandled merge conflicts which broke the automatic merge process.

This PR fixes and reworks the automatic merging process to correctly handle these unexpected and unhandled merge conflicts while also now having a final validate check which will manually synchronize the source repository contents with the repo-staging folder versions. This (at times) may still cause some history to be dropped when the `git merge` incorrectly matches file changes from JS and CONTRIB are the same file. (Lots of testing to avoid and limit this have been performed).