### PR TITLE
chore: Fix script to set user name and email

### DIFF
--- a/sandbox-tools/merge-repos/src/github/github.ts
+++ b/sandbox-tools/merge-repos/src/github/github.ts
@@ -18,7 +18,7 @@ import * as fs from "fs";
 import * as child_process from "child_process";
 import * as util from "util";
 import { SimpleGit} from "simple-git";
-import { log } from "../support/utils";
+import { log, logError } from "../support/utils";
 import path = require("path");
 
 const execFile = util.promisify(child_process.execFile);
@@ -62,6 +62,9 @@ export async function gitHubListForkRepos(gitRoot: string): Promise<GithubRepo[]
         ]).then(async (value) => {
             repos = JSON.parse(value.stdout);
         });
+    } catch(e) {
+        logError("Failed -- Have you installed the GitHub CLI tools https://cli.github.com/");
+        throw e;
     } finally {
         process.chdir(cwd);
     }


### PR DESCRIPTION
This change sets the user.name and user.email on the cloned (local) staging repo so that it can apply it's local changes (that get merged in the temp folder) while identifying itself with the local user (which is the opentelemetrybot for the action) rather than falling back to the global git config user.name and user.email./