### PR TITLE
feat(api-events): add data property to events api

### DIFF
--- a/pkgs/api-events/src/types/Event.ts
+++ b/pkgs/api-events/src/types/Event.ts
@@ -27,8 +27,16 @@ export interface Event {
    */
   name: string;
 
+
+  /**
+   * Attributes that describe the event. 
+   * Intended to be used by instrumentation libraries.
+   */
+  data?: Attributes;
+
   /**
    * Additional attributes that describe the event.
+   * Intended to be used by end uses adding additional attributes.
    */
   attributes?: Attributes;
 


### PR DESCRIPTION
Closes #113 
Unblocks #108 

## Changes
- Adds `data` property to `Event` interface that should be used by instrumentation. `attributes` should only be used to provide additional attributes

## Questions
Do we also need to update the `emit` function here? There was some discussion about making that function take arguments instead of one argument that is the `Event` interface.