### PR TITLE
Add web example for emitting events

### DIFF
--- a/examples/web/js/examples/events/index.html
+++ b/examples/web/js/examples/events/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Fetch Plugin Example</title>
+  <base href="/">
+
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+
+<body>
+  Example of emitting events
+  <script type="text/javascript" src="events.js"></script>
+  <br/>
+  <button id="button1">Test</button>
+
+</body>
+
+</html>

--- a/examples/web/js/examples/events/index.js
+++ b/examples/web/js/examples/events/index.js
@@ -1,0 +1,48 @@
+const { logs } = require('@opentelemetry/sandbox-api-logs');
+const { events } = require('@opentelemetry/sandbox-api-events');
+const { EventEmitterProvider } = require('@opentelemetry/sandbox-sdk-events');
+const {
+  LoggerProvider,
+  SimpleLogRecordProcessor,
+  ConsoleLogRecordExporter,
+} = require('@opentelemetry/sandbox-sdk-logs');
+const { OTLPLogExporter } = require('@opentelemetry/sandbox-exporter-logs-otlp-http');
+
+// The Events SDK has a dependency on the Logs SDK - a global LoggerProvider must be
+// registered. Any processing (e.g. export) is done through the Logs SDK.
+const loggerProvider = new LoggerProvider();
+loggerProvider.addLogRecordProcessor(
+  new SimpleLogRecordProcessor(new ConsoleLogRecordExporter())
+);
+loggerProvider.addLogRecordProcessor(
+  new SimpleLogRecordProcessor(new OTLPLogExporter())
+);
+logs.setGlobalLoggerProvider(loggerProvider);
+
+// Register a global EventEmitterProvider -
+// This would be used by instrumentations, similar to how the global TracerProvider,
+// LoggerProvider and MeterProvider work.
+const eventEmitterProvider = new EventEmitterProvider();
+events.setGlobalEventEmitterProvider(eventEmitterProvider);
+
+// setup instrumentation
+window.addEventListener('load', prepareClickEvent);
+
+function prepareClickEvent() {
+  // get an EventEmitter from the global EventEmitterProvider
+  const eventEmitter = events.getEventEmitter('default');
+
+  const element = document.getElementById('button1');
+  element.addEventListener('click', onClick);
+  
+  function onClick() {
+    // emit an event
+    eventEmitter.emit({
+      name: 'myEvent',
+      data: {
+        field1: 'abc',
+        field2: 123
+      }
+    });
+  };
+}

--- a/examples/web/js/package.json
+++ b/examples/web/js/package.json
@@ -104,7 +104,12 @@
     "@opentelemetry/sandbox-sdk-trace-base": "1.14.0",
     "@opentelemetry/sandbox-sdk-trace-web": "1.14.0",
     "@opentelemetry/sandbox-semantic-conventions": "1.14.0",
-    "tslib": "^2.3.1"
+    "tslib": "^2.3.1",
+    "@opentelemetry/sandbox-api-logs": "~0.40.0",
+    "@opentelemetry/sandbox-sdk-logs": "~0.40.0",
+    "@opentelemetry/sandbox-api-events": "~0.40.0",
+    "@opentelemetry/sandbox-sdk-events": "~0.35.1",
+    "@opentelemetry/sandbox-exporter-logs-otlp-http": "~0.40.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web"
 }

--- a/examples/web/js/webpack.dev.config.js
+++ b/examples/web/js/webpack.dev.config.js
@@ -14,6 +14,7 @@ const common = {
     fetchXhrB3: 'examples/fetchXhrB3/index.js',
     'fetch-proto': 'examples/fetch-proto/index.js',
     zipkin: 'examples/zipkin/index.js',
+    events: 'examples/events/index.js',
   },
   output: {
     path: path.resolve(__dirname, 'dist'),

--- a/examples/web/js/webpack.prod.config.js
+++ b/examples/web/js/webpack.prod.config.js
@@ -14,6 +14,7 @@ const common = {
     fetchXhrB3: 'examples/fetchXhrB3/index.js',
     "fetch-proto": "examples/fetch-proto/index.js",
     zipkin: 'examples/zipkin/index.js',
+    events: 'examples/events/index.js',
   },
   output: {
     path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
I am adding this example to show how the Events SDK is configured. It can also be used as a starting point for testing events-based instrumentations.