### PR TITLE
fix: handle re-adding submodule to the index

### DIFF
--- a/sandbox-tools/merge-repos/src/mergeStagingToMain.ts
+++ b/sandbox-tools/merge-repos/src/mergeStagingToMain.ts
@@ -993,8 +993,14 @@ async function mergeStagingToMaster(mergeGit: SimpleGit, stagingDetails: IStagin
 
     log ("Resetting up submodules");
     for (let lp = 0; lp < _subModules.length; lp++) {
-        log ("adding submodule " + _subModules[lp].path + " => " + _subModules[lp].url);
-        await mergeGit.submoduleAdd(_subModules[lp].url, _subModules[lp].path);
+        try {
+            log ("adding submodule " + _subModules[lp].path + " => " + _subModules[lp].url);
+            await mergeGit.submoduleAdd(_subModules[lp].url, _subModules[lp].path);
+        } catch (e) {
+            if (e.message.indexOf("already exists") === -1) {
+                throw e;
+            }
+        }
     }
 
     // Update the root package json


### PR DESCRIPTION
Fixes issue where `protos` is already present as a submodule as failed in this action run
https://github.com/open-telemetry/opentelemetry-sandbox-web-js/actions/runs/5873142611