### PR TITLE
Race condition workaround

### DIFF
--- a/packages/web-common/src/SessionManager.ts
+++ b/packages/web-common/src/SessionManager.ts
@@ -51,10 +51,9 @@ export class SessionManager implements SessionProvider, SessionPublisher {
     this._observers = [];
 
     this._session = this._storage.get();
-    if (!this._session) {
-      this._session = this.startSession();
+    if (this._session) {
+      this.resetTimers();
     }
-    this.resetTimers();
   }
 
   addObserver(observer: SessionObserver): void {
@@ -63,7 +62,8 @@ export class SessionManager implements SessionProvider, SessionPublisher {
 
   getSessionId(): string | null {
     if (!this._session) {
-      return null;
+      this._session = this.startSession();
+      this.resetTimers();
     }
 
     if (this._maxDuration && (Date.now() - this._session.startTimestamp) > this._maxDuration) {

--- a/packages/web-configuration/src/utils.ts
+++ b/packages/web-configuration/src/utils.ts
@@ -124,6 +124,9 @@ export function getSessionManager(config?: SessionConfiguration): SessionManager
     sessionManager.addObserver(config.sessionObserver);
   }
 
+  // force creation of a new session
+  sessionManager.getSessionId();
+
   return sessionManager;
 }
 


### PR DESCRIPTION
When session is started immediately when SessionManager is created, then observers added later via addObserver() are not notified of the first session start. This delays the creation of the first session until session ID is requested for the first time.