### PR TITLE
Extracted session lifecycle management into a separate component

### DIFF
--- a/examples/session/otel.js
+++ b/examples/session/otel.js
@@ -3,7 +3,7 @@ import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xm
 import { ConsoleLogRecordExporter, SimpleLogRecordProcessor } from '@opentelemetry/sdk-logs';
 import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { configureWebSDK, getResource, getSessionManager } from '@opentelemetry/web-configuration';
-import { WebLocalStorage } from '@opentelemetry/web-common';
+import { DefaultSessionLifecycle, WebLocalStorage } from '@opentelemetry/web-common';
 
 const sessionObserver = {
   onSessionStarted: (session) => {
@@ -21,6 +21,8 @@ const customIdGenerator = {
   }
 }
 
+const sessionLifecycle = new DefaultSessionLifecycle();
+
 configureWebSDK(
   {
     logRecordProcessors: [new SimpleLogRecordProcessor(new ConsoleLogRecordExporter())],
@@ -29,11 +31,10 @@ configureWebSDK(
       serviceName: 'My app',
     }),
     sessionIdProvider: getSessionManager({
-      maxDuration: 20000,
-      idleTimeout: 10000,
       sessionStorage: new WebLocalStorage(),
       sessionIdGenerator: customIdGenerator,
-      sessionObserver: sessionObserver
+      sessionObserver: sessionObserver,
+      sessionLifecycle: new DefaultSessionLifecycle(20000, 10000)
     })
   },
   [

--- a/packages/web-common/src/DefaultSessionLifecycle.ts
+++ b/packages/web-common/src/DefaultSessionLifecycle.ts
@@ -1,0 +1,116 @@
+
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Session } from "./types/Session";
+import { SessionLifecycle } from "./types/SessionLifecycle";
+
+export class DefaultSessionLifecycle implements SessionLifecycle {
+  private _maxDuration?: number;
+  private _maxDurationTimeoutId?: ReturnType<typeof setTimeout>;
+  private _inactivityTimeout?: number;
+  private _inactivityTimeoutId?: ReturnType<typeof setTimeout>;
+  private _lastActivityTimestamp: number = 0;
+  private _inactivityResetDelay: number = 5000; // minimum time between activities before timer is reset
+  private _timeoutListener: (() => void) | undefined;
+  private _session: Session | undefined;
+
+  constructor(maxDuration?: number, inactivityTimeout?: number) {
+    this._maxDuration = maxDuration;
+    this._inactivityTimeout = inactivityTimeout;
+  }
+  
+  onSessionEnded(listener: () => void): void {
+    this._timeoutListener = listener;
+  }
+
+  public start(session: Session) {
+    this._session = session;
+    this.resetTimers();
+  }
+
+  public clear() {
+    if (this._inactivityTimeoutId) {
+      clearTimeout(this._inactivityTimeoutId);
+      this._inactivityTimeoutId = undefined;
+    }
+
+    if (this._maxDurationTimeoutId) {
+      clearTimeout(this._maxDurationTimeoutId);
+      this._maxDurationTimeoutId = undefined;
+    }
+
+    this._session = undefined;
+  }
+
+  public bumpSessionActive() {
+    if (!this._session) {
+      return;
+    }
+
+    if (this._maxDuration && (Date.now() - this._session.startTimestamp) > this._maxDuration) {
+      this.notifySessionEnded();
+    }
+
+    if (this._inactivityTimeout) {
+      if (Date.now() - this._lastActivityTimestamp > this._inactivityResetDelay) {
+        this.resetIdleTimer();
+        this._lastActivityTimestamp = Date.now();
+      }
+    }
+  }
+
+  private notifySessionEnded() {
+    if (this._timeoutListener) {
+      this._timeoutListener();
+    }
+  }
+
+  private resetTimers() {
+    if (this._inactivityTimeout) {
+      this.resetIdleTimer();
+    }
+    if (this._maxDuration) {
+      this.resetMaxDurationTimer();
+    }
+  }
+
+  private resetIdleTimer() {
+    if (this._inactivityTimeoutId) {
+      clearTimeout(this._inactivityTimeoutId);
+    }
+
+    this._inactivityTimeoutId = setTimeout(() => {
+      this.notifySessionEnded();
+    }, this._inactivityTimeout);
+  }
+
+  private resetMaxDurationTimer() {
+    if (!this._maxDuration || !this._session) {
+      return
+    }
+
+    if (this._maxDurationTimeoutId) {
+      clearTimeout(this._maxDurationTimeoutId);
+    }
+    
+    const timeoutIn = this._maxDuration - (Date.now() - this._session?.startTimestamp);
+
+    this._maxDurationTimeoutId = setTimeout(() => {
+      this.notifySessionEnded();
+    }, timeoutIn);
+  }
+}

--- a/packages/web-common/src/index.ts
+++ b/packages/web-common/src/index.ts
@@ -26,3 +26,5 @@ export { SessionManager } from './SessionManager';
 export { WebSessionStorage } from './WebSessionStorage';
 export { WebLocalStorage } from './WebLocalStorage';
 export { DefaultIdGenerator } from './DefaultIdGenerator';
+export { SessionLifecycle } from './types/SessionLifecycle';
+export { DefaultSessionLifecycle } from './DefaultSessionLifecycle';

--- a/packages/web-common/src/types/SessionLifecycle.ts
+++ b/packages/web-common/src/types/SessionLifecycle.ts
@@ -1,0 +1,32 @@
+
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Session } from "./Session";
+
+export interface SessionLifecycle {
+  /** Starts tracking a new session */
+  start(session: Session): void;
+
+  /** Stop tracking the current session, reset to a clear state */
+  clear(): void;
+
+  /** Notifies this class that the session is currently active. */
+  bumpSessionActive(): void;
+
+  /** Register a listener function to call when session is ended. */
+  onSessionEnded(listener: () => void): void;
+}

--- a/packages/web-configuration/src/utils.ts
+++ b/packages/web-configuration/src/utils.ts
@@ -30,7 +30,7 @@ import { BatchLogRecordProcessor, LoggerProvider, LoggerProviderConfig, LogRecor
 import { BatchSpanProcessor, SpanExporter, SpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { WebTracerConfig, WebTracerProvider } from "@opentelemetry/sdk-trace-web";
 import { SEMRESATTRS_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
-import { DefaultIdGenerator, SessionIdGenerator, SessionIdProvider, SessionLogRecordProcessor, SessionManager, SessionObserver, SessionSpanProcessor, SessionStorage, WebSessionStorage } from "@opentelemetry/web-common";
+import { DefaultIdGenerator, DefaultSessionLifecycle, SessionIdGenerator, SessionIdProvider, SessionLifecycle, SessionLogRecordProcessor, SessionManager, SessionObserver, SessionSpanProcessor, SessionStorage, WebSessionStorage } from "@opentelemetry/web-common";
 import { browserDetector } from '@opentelemetry/opentelemetry-browser-detector';
 
 export interface ResourceConfiguration {
@@ -42,9 +42,8 @@ export interface ResourceConfiguration {
 export interface SessionConfiguration {
   sessionIdGenerator?: SessionIdGenerator;
   sessionStorage?: SessionStorage;
-  maxDuration?: number;
-  idleTimeout?: number;
-  sessionObserver: SessionObserver
+  sessionObserver: SessionObserver;
+  sessionLifecycle: SessionLifecycle
 }
 
 export interface TraceSDKConfiguration {
@@ -112,12 +111,12 @@ export function getResource(config?: ResourceConfiguration): Resource {
 export function getSessionManager(config?: SessionConfiguration): SessionManager {
   const idGenerator = config?.sessionIdGenerator || new DefaultIdGenerator();
   const storage = config?.sessionStorage || new WebSessionStorage();
+  const lifecycle = config?.sessionLifecycle || new DefaultSessionLifecycle();
 
   const sessionManager = new SessionManager({
     sessionIdGenerator: idGenerator,
     sessionStorage: storage,
-    maxDuration: config?.maxDuration,
-    idleTimeout: config?.idleTimeout
+    sessionLifecycle: lifecycle
   });
 
   if (config?.sessionObserver) {


### PR DESCRIPTION
SessionManager is currently handling max duration and inactivity timeouts. There might be use cases when starting and ending a session should be customized. This is an attempt to extract the session lifecycle logic into a separate component.